### PR TITLE
feat: add Dependabot config for git submodule monitoring

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global code owners for all files in the repository
+* @key
+
+# Specific ownership for git submodule updates
+MCP251XFD/ @key
+
+# Dependabot configuration files
+.github/dependabot.yml @key

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
-    reviewers:
-      - "KenosInc"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "KenosInc"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Add Dependabot configuration to automatically monitor MCP251XFD git submodule for updates
- Configure weekly checks every Monday at 09:00 JST
- Limit to 5 concurrent pull requests
- Auto-assign KenosInc team for review

## Benefits

- Automated submodule updates keep the MCP251XFD library current
- Reduces manual maintenance overhead
- Ensures security patches and improvements are pulled in regularly

## Test plan

- [ ] Verify Dependabot configuration is valid
- [ ] Confirm scheduled checks appear in GitHub repository insights
- [ ] Test that pull requests are created when submodule updates are available

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated dependency-update configuration with weekly scheduled checks.
  * Added repository code ownership rules to clarify file and directory maintainers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->